### PR TITLE
Implement direct mentions @dibs

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,25 @@ app.command(`/${process.env.COMMAND}`, async ({ command, ack, say }) => {
   }
 });
 
+// Respond to direct mentions, e.g. @dibs
+app.event("app_mention", async ({ event, say }) => {
+  if (event.text.includes("on")) {
+    // given "on staging for 1 hour"
+    // match[1] = "staging"
+    // match[2] = "1 hour"
+    const match = parseOnCommand(event.text);
+    const duration = await parseDuration(match[2]);
+
+    // call dibs
+    reserveResource(match[1], event.user, duration);
+  } else if (event.text.includes("off")) {
+    // given "off staging"
+    // match[1] = "staging"
+    const match = parseOffCommand(event.text);
+    releaseResource(match[1], event.user);
+  }
+});
+
 eventEmitter.on(Events.RELEASED, async (name, user) => {
   await app.client.chat.postMessage({
     channel: channel,
@@ -89,7 +108,6 @@ eventEmitter.on(Events.ERROR_ALREADY_IN_QUEUE, async (resource, user) => {
     text: `<@${user}> is already in queue for \`${resource}\``,
   });
 });
-
 
 (async () => {
   // Start your app


### PR DESCRIPTION
### Overview

- in addition to `/dibs`, you can now use `@dibs` to send the command as a direct message:

```
/dibs on staging for 15 minutes
@dibs on staging for 15 minutes
```

- this will allow 3rd parties to reserve resources without adding the app to their workspace

### Config changes

- requires enabling events for the Slack app:

<img width="300" alt="Screenshot 2025-03-16 at 8 21 07 PM" src="https://github.com/user-attachments/assets/7e1b3694-f7ac-4cbe-971b-9f0f3e9adb16" />

- also requires the [`app_mentions:read` OAuth permission](https://api.slack.com/scopes/app_mentions:read)